### PR TITLE
Initialize _wall_profiler when we start the server

### DIFF
--- a/pypprof/net_http.py
+++ b/pypprof/net_http.py
@@ -23,7 +23,7 @@ from pypprof.builder import Builder
 from pypprof import thread_profiler
 
 
-_wall_profiler = WallProfiler()
+_wall_profiler = None
 
 
 def start_pprof_server(host='localhost', port=8080):
@@ -38,6 +38,9 @@ def start_pprof_server(host='localhost', port=8080):
     # on the main thread. So do it now before spawning the background thread.
     # As a result, starting the pprof server has the side effect of registering the
     # wall-clock profiler's SIGALRM handler, which may conflict with other uses.
+    global _wall_profiler
+    if _wall_profiler is None:
+        _wall_profiler = WallProfiler()
     _wall_profiler.register_handler()
 
     server = HTTPServer((host, port), PProfRequestHandler)


### PR DESCRIPTION
I ran into this issue when using a Python 3.7 distroless docker image.

The container will error unless we move `_wall_profiler` into a function so it is created after the python shell starts up.

![Screen Shot 2020-10-30 at 11 40 44 AM](https://user-images.githubusercontent.com/619921/97729656-4edf8a00-1aa9-11eb-8c80-159589388915.png)
